### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,3 +17,4 @@ jobs:
       run: |
         chmod +x gradlew
         ./gradlew build
+        ./gradlew test


### PR DESCRIPTION
I just discovered that we can do CI through GitHub with GitHub Actions so I threw together a config that would run the same build/test process as the Travis config. My main reason for switching is that I think it's cool that all of this can be done through GitHub, and it means that you don't have to switch between sites to see what went wrong if a build fails.